### PR TITLE
Fix detecting pytest repo

### DIFF
--- a/scripts/run_python_tests.sh
+++ b/scripts/run_python_tests.sh
@@ -26,7 +26,6 @@ if [[ -f "${targetDirectory}/Pipfile" ]]; then
   if [[ ! -f "Pipfile.lock" ]]; then
     pipenv install
   fi
-  pipenv sync
   pipenv sync --dev
   cd "$workingDirectory"
 fi

--- a/scripts/run_python_tests.sh
+++ b/scripts/run_python_tests.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 IFS=$'\n\t'
 ###############################################################
 
+workingDirectory=$(pwd)
 testsDirectory="${PYTHON_TESTS_DIR:-.}"
 targetDirectory="$PYTHON_TARGET_DIR"
 coverageDirectory="${PYTHON_COVERAGE_DIR:-$targetDirectory}"
@@ -27,7 +28,7 @@ if [[ -f "${targetDirectory}/Pipfile" ]]; then
   fi
   pipenv sync
   pipenv sync --dev
-  cd -
+  cd "$workingDirectory"
 fi
 
 if grep -q -R pytest --include '*.py' "${targetDirectory}"; then
@@ -39,7 +40,7 @@ if grep -q -R pytest --include '*.py' "${targetDirectory}"; then
     --cov="${coverageDirectory}" \
     --junitxml=tests.xml
   pipenv run coverage xml
-  cd -
+  cd "$workingDirectory"
 else
   echo "Running tests using nosetests..."
   nosetests -v \

--- a/scripts/run_python_tests.sh
+++ b/scripts/run_python_tests.sh
@@ -30,7 +30,7 @@ if [[ -f "${targetDirectory}/Pipfile" ]]; then
   cd -
 fi
 
-if grep -q -R pytest --include *.py "${targetDirectory}"; then
+if grep -q -R pytest --include '*.py' "${targetDirectory}"; then
   echo "Running tests using pytest..."
   cd "${targetDirectory}"
   PYTHONPATH="${coverageDirectory}" pipenv run pytest \


### PR DESCRIPTION
- Fix detecting pytest repo _Enclose glob expression in quotes to have it evaluated by grep as it
recurses rather than by the shell in the current dir only._
- Ensure original working directory is restored after change. _When the target directory was . the old code would move you up one_
- Remove repeated pipenv sync