### PR TITLE
Prevent passing empty arg which confuses pipenv sync

### DIFF
--- a/scripts/run_python_tests.sh
+++ b/scripts/run_python_tests.sh
@@ -31,7 +31,7 @@ if [[ -f "${targetDirectory}/Pipfile" ]]; then
   if [[ ! -f "Pipfile.lock" ]]; then
     pipenv install "${VERBOSE}"
   fi
-  pipenv sync --dev "${VERBOSE}"
+  pipenv sync --dev $VERBOSE
   cd "$workingDirectory"
 fi
 


### PR DESCRIPTION
When the DEBUG flag is not set, the run_python_test workflow [fails](https://github.com/pi-top/pt-further-link/pull/43/checks?check_run_id=2401758882) during pipenv sync with the output:
```Pipfile found, installing...
Usage: pipenv sync [OPTIONS]
Try 'pipenv sync -h' for help.

Error: Got unexpected extra argument ()
Error: Process completed with exit code 2.```
```
This is because the pipenv sync subcommand does not like being called with an extra empty argument:
```
❯ pipenv sync --dev ""
Usage: pipenv sync [OPTIONS]

Error: Got unexpected extra argument ()
```

So this is simply fixed by doing the bash string expansion without enclosing quotes. I'm not sure if there is a preferred way to handle this or we want to apply it to other places in this script. I don't think other pipenv subcommands have this problem.